### PR TITLE
fixed PWA install

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="./static/stylesheets/app.css">
     <link rel="icon" href="./static/graphicarts/favicon.svg" type="image/svg+xml">
     <link rel="alternate icon" href="./static/graphicarts/favicon.png" type="image/png">
-    <link rel="manifest" href="./manifest.json" />
+    <link rel="manifest" href="manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <script>
         window.app = window.app || {}

--- a/assets/javascripts/sw.js
+++ b/assets/javascripts/sw.js
@@ -1,4 +1,4 @@
-const VERSION = "v3.1.0"
+const VERSION = "v3.1.1"
 const APP_STATIC_RESOURCES = [
   "/",
   "/static/stylesheets/bootstrap.min.css",

--- a/server/routes.go
+++ b/server/routes.go
@@ -86,7 +86,7 @@ func (s *Server) handleManifest(c *router.Context) {
 		"short_name":  "yarr",
 		"description": "yet another rss reader",
 		"display":     "standalone",
-		"start_url":   s.BasePath,
+		"start_url":   "/" + s.BasePath,
 		"icons": []map[string]interface{}{
 			{
 				"src":   s.BasePath + "/static/graphicarts/favicon.png",


### PR DESCRIPTION
Goes to show you should actually test these things :laughing:. Found a bug where after installing, closing and then opening the app would just show the manifest. This fixes the routing so the front page actually loads after first install.