### PR TITLE
Build a multi-arch Docker image (amd64 and arm64)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,6 +3,11 @@ name: Publish Docker image
 on:
   release:
     types: [published]
+    
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  TARGET_PLATFORMS: linux/amd64,linux/arm64
 
 jobs:
   push_to_registry:
@@ -12,17 +17,24 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
-      - name: Log in to Docker Hub
+      - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: jgkawell/yarr
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
@@ -32,3 +44,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: ${{ env.TARGET_PLATFORMS }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
     
 env:
-  REGISTRY: ghcr.io
+  REGISTRY: ${{ vars.REGISTRY || 'docker.io' }}
   IMAGE_NAME: ${{ github.repository }}
   TARGET_PLATFORMS: linux/amd64,linux/arm64
 
@@ -21,8 +21,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_USERNAME || (env.REGISTRY == 'ghcr.io' && github.actor) }}
+          password: ${{ secrets.DOCKER_PASSWORD || (env.REGISTRY == 'ghcr.io' && secrets.GITHUB_TOKEN) }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine AS build
+FROM --platform=$BUILDPLATFORM golang:alpine AS build
 
 WORKDIR /app
 
@@ -7,7 +7,9 @@ COPY . .
 RUN go mod download
 RUN go mod verify
 
-RUN GOOS=linux GOARCH=amd64 go build -o bin/yarr .
+ARG TARGETOS
+ARG TARGETARCH
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o bin/yarr .
 
 FROM alpine:latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM --platform=$BUILDPLATFORM golang:alpine AS build
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /app
 
@@ -7,8 +9,6 @@ COPY . .
 RUN go mod download
 RUN go mod verify
 
-ARG TARGETOS
-ARG TARGETARCH
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o bin/yarr .
 
 FROM alpine:latest


### PR DESCRIPTION
This changeset will build multi-arch Docker images for both amd64 and arm64 using Docker Buildx and Go's excellent built-in cross-platform capabilities. The GitHub CD pipeline is further parameterized to make it easier for forks to deploy to the GitHub Container Registry.